### PR TITLE
Detect Docker robustly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all: build
 
 build: 
 	@echo "Checking if Docker is available..."
-	@if command -v docker &> /dev/null ; then \
+	@if command -v docker >/dev/null 2>&1 ; then \
 		echo "Docker is available, building inside Docker container..."; \
 		$(MAKE) build-container; \
 	else \


### PR DESCRIPTION
`&> /dev/null` works as a redirection from `stdout` and `stderr` to `/dev/null` in Bash but not in POSIX shell (considered as an asynchronous execution and the result of the `command` command cannot be retrieved).

As a result, it always assumes that Docker always exists.

This commit makes the redirection robust and portable (uses `>/dev/null 2>&1` instead, makes it possible to detect "no Docker" condition correctly).

This is a port of now merged riscv/docs-spec-template#14.